### PR TITLE
Added Cracked Tiles Prototype

### DIFF
--- a/.idea/.idea.bouncentrate/.idea/indexLayout.xml
+++ b/.idea/.idea.bouncentrate/.idea/indexLayout.xml
@@ -20,6 +20,7 @@
       <Path>GyroskopTouchControlls</Path>
       <Path>Library</Path>
       <Path>Logs</Path>
+      <Path>Temp</Path>
       <Path>obj</Path>
     </explicitExcludes>
   </component>

--- a/Assets/1_Scenes/HexagonTiles.unity
+++ b/Assets/1_Scenes/HexagonTiles.unity
@@ -129,7 +129,7 @@ GameObject:
   - component: {fileID: 1330988571}
   m_Layer: 0
   m_Name: Ball
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -392,7 +392,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1850277874}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 10, z: -0.61}
+  m_LocalPosition: {x: 0, y: 18.92, z: -0.61}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/3_Scripts/BallCollision.cs
+++ b/Assets/3_Scripts/BallCollision.cs
@@ -2,11 +2,19 @@
 
 public class BallCollision : MonoBehaviour
 {
+    private float delay = 2f;
     void OnCollisionEnter(Collision collisionInfo)
+    
     {
         if(collisionInfo.collider.tag == "Tile")
         {
             collisionInfo.collider.GetComponent<Renderer> ().material.color = Color.red;
+        }
+        
+        if(collisionInfo.collider.tag == "Cracked Tile")
+        {
+            collisionInfo.collider.GetComponent<Renderer> ().material.color = Color.blue;
+            Destroy (collisionInfo.collider.gameObject, delay);
         }
     }
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Ground
   - Tile
+  - Cracked Tile
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Added a method into the BallCollision Script that changes the Color of the Tiles that are flagged with the Cracked Tile Tag to Blue and destroys them after 2 seconds. You have to flag the Prefab itself and the child of the prefab!